### PR TITLE
Chore: (Docs) Updates link for support table

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Storybook Addon Cssresources to switch between css resources at runtime for your story [Storybook](https://storybook.js.org).
 
-[Framework Support](https://github.com/storybookjs/storybook/blob/master/ADDONS_SUPPORT.md)
+[Framework Support](https://storybook.js.org/docs/react/api/frameworks-feature-support)
 
 ![Storybook Addon Cssresources Demo](docs/demo.gif)
 


### PR DESCRIPTION
With this small pull request, the Framework support link is updated to its proper location as the Addon Support table is no longer a source of truth.

Addresses #17150